### PR TITLE
Add `argc` and `argv` to `main`

### DIFF
--- a/_execute.c
+++ b/_execute.c
@@ -8,10 +8,11 @@
  * _exec_in_child - Executes a program/command, inside of a child process.
  * @command: The program/command to execute.
  * @args: Command line arguments for the program being executed.
+ * @argv: Argument vector first used when invoking the shell.
  * Description: Executes a program/command, inside of a child process.
  * Return: 0 on success, -1 on error.
 */
-int _exec_in_child(char *command, char **args)
+int _exec_in_child(char *command, char **args, char **argv)
 {
 	pid_t fork_num;
 	int wait_status;
@@ -22,11 +23,12 @@ int _exec_in_child(char *command, char **args)
 		perror("Error");
 		return (-1);
 	}
+
 	if (fork_num == 0) /* Child process */
 	{
 		if (execvp(command, args) == -1)
 		{
-			perror("Error");
+			perror(argv[0]);
 		}
 		_exit(0);
 	}

--- a/shell.c
+++ b/shell.c
@@ -4,10 +4,12 @@
 
 /**
  * main - Entry point.
+ * @argc: The number of arguments.
+ * @argv: The array of arguments.
  * Description: The main entry point of the program.
  * Return: 0 if successful, Non-zero otherwise.
  */
-int main(void)
+int main(__attribute__((unused)) int argc, char **argv)
 {
 	char *input;
 	char **args;
@@ -22,7 +24,7 @@ int main(void)
 		args = _get_tokens(input, " ");
 		if (_is_exit_call(args))
 			__exit();
-		if (_exec_in_child(args[0], args) == -1)
+		if (_exec_in_child(args[0], args, argv) == -1)
 			break;
 	}
 

--- a/shell.h
+++ b/shell.h
@@ -30,7 +30,7 @@ char **_get_tokens(char *str, char *delims);
 char *_get_prompt_input(void);
 
 /* Executes a program/command, inside of a child process. */
-int _exec_in_child(char *command, char **args);
+int _exec_in_child(char *command, char **args, char **argv);
 
 /* Checks if the command is a call to the exit command. */
 int _is_exit_call(char **command);


### PR DESCRIPTION
`main`'s signature now includes classic argc & argv parameters. `argv` is used when printing error messages to the `hsh` shell.