### PR TITLE
Refactor: Simplify signature for `_exec_in_child`

### DIFF
--- a/_execute.c
+++ b/_execute.c
@@ -6,16 +6,18 @@
 
 /**
  * _exec_in_child - Executes a program/command, inside of a child process.
- * @command: The program/command to execute.
  * @args: Command line arguments for the program being executed.
  * @argv: Argument vector first used when invoking the shell.
  * Description: Executes a program/command, inside of a child process.
  * Return: 0 on success, -1 on error.
 */
-int _exec_in_child(char *command, char **args, char **argv)
+int _exec_in_child(char **args, char **argv)
 {
 	pid_t fork_num;
 	int wait_status;
+	char *command;
+
+	command = args[0];
 
 	fork_num = fork();
 	if (fork_num == -1)

--- a/shell.c
+++ b/shell.c
@@ -24,7 +24,7 @@ int main(__attribute__((unused)) int argc, char **argv)
 		args = _get_tokens(input, " ");
 		if (_is_exit_call(args))
 			__exit();
-		if (_exec_in_child(args[0], args, argv) == -1)
+		if (_exec_in_child(args, argv) == -1)
 			break;
 	}
 

--- a/shell.h
+++ b/shell.h
@@ -36,7 +36,7 @@ char **_get_tokens(char *str, char *delims);
 char *_get_prompt_input(void);
 
 /* Executes a program/command, inside of a child process. */
-int _exec_in_child(char *command, char **args, char **argv);
+int _exec_in_child(char **args, char **argv);
 
 /* Checks if the command is a call to the exit command. */
 int _is_exit_call(char **command);


### PR DESCRIPTION
The `command` parameter has been removed, since it is just the value of `args[0]`.
The command is now extracted from within the `_exec_in_child` function itself.