### PR TITLE
Refactor: Rename `is_command` to `is_same`

### DIFF
--- a/_is_command.c
+++ b/_is_command.c
@@ -2,13 +2,13 @@
 #include "shell.h"
 
 /**
- * is_command - Checks if string s1 is the same as the command, s2.
+ * is_same - Checks if string s1 is the same as the command, s2.
  * @s1: The string to check.
  * @s2: The command to be used for checking.
  * Description: Checks if string s1 is the same as the command, s2.
  * Return: 1 if s1 is the same as s2, 0 otherwise.
 */
-int is_command(char *s1, char *s2)
+int is_same(char *s1, char *s2)
 {
 	return (_strcmp(s1, s2) == 0);
 }

--- a/shell.c
+++ b/shell.c
@@ -33,13 +33,13 @@ int main(__attribute__((unused)) int argc, char **argv, char **env)
 
 		args = get_tokens(input, DELIMS);
 		command = args[0];
-
-		if (is_command(command, "exit")) /* exit immediately */
+		printf("command is: %s\n", command);
+		if (is_same(command, "exit")) /* exit immediately */
 		{
 			free(input);
 			__exit();
 		}
-		if (is_command(command, "env")) /* print the environment*/
+		if (is_same(command, "env")) /* print the environment */
 		{
 			print_env(env);
 			free(input);

--- a/shell.h
+++ b/shell.h
@@ -35,7 +35,7 @@ int _strcmp(char *s1, char *s2);
 int starts_with(char *s1, char *s2);
 
 /* Checks if string s1 is the same as the command, s2. */
-int is_command(char *s1, char *s2);
+int is_same(char *s1, char *s2);
 
 /* Returns the argument count for the program/command entered. */
 int _argc(char **argv);


### PR DESCRIPTION
The function was renamed so it can be re-used in other contexts that do not involve checking a command specifically, without risking a miscommunication.