### PR TITLE
Add `,nointeract` script for non-interactive mode

### DIFF
--- a/dev-scripts/,nointeract
+++ b/dev-scripts/,nointeract
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument("command",
+					help="The command to run in non-interactive mode")
+parser.add_argument("--valgrind", "-v", action="store_true",
+					help="Produces a valgrind summary after running the command")
+args = parser.parse_args()
+
+command = args.command
+valgrind = "valgrind --leak-check=full --track-origins=yes" if args.valgrind else ""
+
+to_run = f"echo \"{command}\" | {valgrind} ./hsh"
+
+# compile the program first
+subprocess.run(",compile", shell=True)
+
+# run the command in non-interactive mode
+subprocess.run(to_run, shell=True)

--- a/dev-scripts/README.md
+++ b/dev-scripts/README.md
@@ -77,3 +77,52 @@ $ ,compile -s -v
 ==102431== 
 $ 
 ```
+
+### ,nointeract
+
+Runs the shell program in non-interactive mode, by echoing the command and piping
+\
+it into the hsh shell.
+\
+\
+Simplest usage is: `,nointeract "<command to run>"`
+
+```sh
+$ ,nointeract "ls -h"   
+a.out                 _env.c             _get_tokens.c   _putchar.c      _strcat.c        _strlen.c
+_atoi.c               _execute.c         hsh             _puts.c         _strchr.c        _strncpy.c
+AUTHORS               _execvp.c          _is_command.c   README.md       _str_clean_up.c  tests
+callgrind.out.142952  exercises          _isdigit.c      _set.c          _strcmp.c
+_concatenate.c        _exit.c            _lengths.c      shell.c         _strcmpr.c
+_delimiting.c         find_executable.c  LICENSE         shell.h         _strcpy.c
+dev-scripts           _freeing.c         _prompt_input.c _starts_with.c  _strdup.c
+```
+
+If the `-v` (or `--valgrind`) flag is used, a valgrind report is generated after
+\
+the program has been run.
+
+```sh
+$ ,nointeract "ls -h" -v
+==767453== Memcheck, a memory error detector
+==767453== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==767453== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
+==767453== Command: ./hsh
+==767453== 
+a.out                 _env.c             _get_tokens.c   _putchar.c      _strcat.c        _strlen.c
+_atoi.c               _execute.c         hsh             _puts.c         _strchr.c        _strncpy.c
+AUTHORS               _execvp.c          _is_command.c   README.md       _str_clean_up.c  tests
+callgrind.out.142952  exercises          _isdigit.c      _set.c          _strcmp.c
+_concatenate.c        _exit.c            _lengths.c      shell.c         _strcmpr.c
+_delimiting.c         find_executable.c  LICENSE         shell.h         _strcpy.c
+dev-scripts           _freeing.c         _prompt_input.c _starts_with.c  _strdup.c
+==767453== 
+==767453== HEAP SUMMARY:
+==767453==     in use at exit: 0 bytes in 0 blocks
+==767453==   total heap usage: 24 allocs, 24 frees, 6,583 bytes allocated
+==767453== 
+==767453== All heap blocks were freed -- no leaks are possible
+==767453== 
+==767453== For lists of detected and suppressed errors, rerun with: -s
+==767453== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+```


### PR DESCRIPTION
Running commands in non-interactive mode can now be more automated with the `,nointeract` script, such that:

`echo "ls -h" | ./hsh`
becomes
`,nointeract "ls -h"`

and,

`echo "ls -h" | valgrind --leak-check=full --track-origins=yes ./hsh`
becomes
`,nointeract "ls -h" -v`