### PR TITLE
Feat: Add a memory pool to store malloced memory

### DIFF
--- a/_mempool.c
+++ b/_mempool.c
@@ -1,0 +1,57 @@
+#include "shell.h"
+#include <stdlib.h>
+
+/**
+ * create_mem_pool - Creates a mem pool, that stores memory locations that have
+ *                   been created with malloc.
+ * Description: Creates a mem pool, that stores memory locations that have
+ *              been created with malloc.
+ * Return: A memory pool struct.
+*/
+memPool *create_mem_pool()
+{
+	memPool *mem_pool;
+
+	mem_pool = (memPool *)malloc(sizeof(memPool));
+	mem_pool->nextFreeIndex = 0;
+
+	return (mem_pool);
+}
+
+/**
+ * append_memory - Adds a memory location to the memory pool.
+ * @pool: The memory pool where the memory location will be added.
+ * @memory: The memory location that will be added.
+ * Description: Adds a memory location to the memory pool.
+ * Return: The next free location in the pool where
+ *         a memory location can be added.
+*/
+int append_memory(memPool *pool, char *memory)
+{
+	int index;
+
+	index = pool->nextFreeIndex;
+	pool->memArray[index] = memory;
+	pool->nextFreeIndex++;
+
+	return (pool->nextFreeIndex);
+}
+
+/**
+ * free_mem_pool - Frees all memory locations in the memory pool.
+ * @pool: The memory pool with locations to free.
+ * Description: Frees all memory locations in the memory pool.
+ * Return: Nothing.
+*/
+void free_mem_pool(memPool *pool)
+{
+	char **poolPtr;
+
+	poolPtr = pool->memArray;
+	while (*poolPtr != NULL)
+	{
+		free(*poolPtr);
+		poolPtr++;
+	}
+	free(pool);
+}

--- a/_set.c
+++ b/_set.c
@@ -7,10 +7,11 @@
  * @key: The key to search for in the environment.
  * @value: The value to assign to the key, in the environment.
  * @env: The current environment variables.
+ * @pool: The memory pool to store malloced memory.
  * Description: Checks if an environment variable with this key exists.
  * Return: 0 on success, -1 otherwise.
 */
-int _setenv(char *key, char *value, char **env)
+int _setenv(char *key, char *value, char **env, memPool *pool)
 {
 	char *new_var;
 	char **envPtr;
@@ -22,6 +23,9 @@ int _setenv(char *key, char *value, char **env)
 	if (key_exists(key, envPtr, &index))
 	{
 		new_var = concat_all(3, key, "=", value);
+		if (!new_var)
+			return -1;
+		append_memory(pool, new_var);
 		env[index] = new_var;
 		return (0);
 	}

--- a/shell.c
+++ b/shell.c
@@ -20,9 +20,11 @@ int main(__attribute__((unused)) int argc, char **argv, char **env)
 	char **args;
 	char *input, *command, *dir_mem, *executable_path, *env_path;
 	int is_interactive;
+	memPool *pool;
 	const int MAX_DIR_LEN = 1024;
 
 	is_interactive = isatty(STDIN_FILENO);
+	pool = create_mem_pool();
 
 	while (1)
 	{
@@ -48,7 +50,8 @@ int main(__attribute__((unused)) int argc, char **argv, char **env)
 
 		if (is_same(command, "setenv"))
 		{
-			_setenv(args[1], args[2], env);
+			_setenv(args[1], args[2], env, pool);
+			free_mem_pool(pool);
 			free(input);
 			continue;
 		}

--- a/shell.h
+++ b/shell.h
@@ -4,6 +4,21 @@
 /* Delimiters with which to tokenize inputs */
 #define DELIMS " \n"
 
+/* struct to hold malloced memory locations */
+typedef struct memPool {
+	char *memArray[50];
+	int nextFreeIndex;
+} memPool;
+
+/* Creates a mem pool, that stores memory locations */
+memPool *create_mem_pool();
+
+/* Adds a memory location to the memory pool. */
+int append_memory(memPool *pool, char *memory);
+
+/* Frees all memory locations in the memory pool. */
+void free_mem_pool(memPool *pool);
+
 /* Writes a character to standard out. */
 int _putchar(char ch);
 
@@ -72,7 +87,7 @@ void __exit(void);
 int _is_env(char **args);
 
 /* Change or add an environment variable. */
-int _setenv(char *key, char *value, char **env);
+int _setenv(char *key, char *value, char **env, memPool *pool);
 
 /* Checks if an environment variable with a given key exists. */
 int key_exists(char *key, char **env, int *index);


### PR DESCRIPTION
In functions that request for memory with malloc, but do not themselves return that memory (so it can be directly freed in main--or some other function), a memory pool (a.k.a mem pool) will be utilized to store those memory locations so that it can later be freed properly.

The mem pool has to be passed into such a function as a parameter for the strategy to work.